### PR TITLE
Update missing step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Onsen UI project templates for Cordova and Visual Studio 2015.
 
 ```
 $ npm install gulp -g
+$ npm install
 $ gulp build [--vsix <version>]
 
 // Only Cordova templates


### PR DESCRIPTION
Just a minor tweak to README.md to add missing step of 'npm install' to install dependancies from package.json
